### PR TITLE
Removed statements that were printing credentials on browser

### DIFF
--- a/linkedin-client.js
+++ b/linkedin-client.js
@@ -6,7 +6,6 @@ LinkedIn = {};
 //   completion. Takes one argument, credentialToken on success, or Error on
 //   error.
 LinkedIn.requestCredential = function (options, credentialRequestCompleteCallback) {
-  console.log('🔑', 'LinkedIn.requestCredential');
   // support both (options, callback) and (callback).
   if (!credentialRequestCompleteCallback && typeof options === 'function') {
     credentialRequestCompleteCallback = options;
@@ -14,10 +13,8 @@ LinkedIn.requestCredential = function (options, credentialRequestCompleteCallbac
   }
 
   const config = ServiceConfiguration.configurations.findOne({service: 'linkedin'});
-  console.log('🔑 config', config);
   if (!config) {
     credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError("Service not configured"));
-    console.log('🔑', 'returning no config');
     return;
   }
 


### PR DESCRIPTION
There are some console.log statements that are printing credentials values in the browser console.