### PR TITLE
Fix linkedin api v2 regressions in related to email address

### DIFF
--- a/linkedin-server.js
+++ b/linkedin-server.js
@@ -15,7 +15,7 @@ const getImage = profilePicture => {
 }
 
 // Request for email, returns array
-const getRegisteredEmails = function(accessToken) {
+const getEmails = function(accessToken) {
   const url = encodeURI(
     `https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))&oauth2_access_token=${accessToken}`,
   )
@@ -137,18 +137,18 @@ OAuth.registerService('linkedin', 2, null, query => {
     expiresAt: +new Date() + 1000 * response.expiresIn,
   }
 
-  const registeredEmails = getRegisteredEmails(accessToken)
+  const emails = getEmails(accessToken)
 
   const fields = {
     linkedinId: id,
     firstName,
     lastName,
     profilePicture: getImage(profilePicture),
-    registeredEmails,
+    emails,
   }
 
-  if (registeredEmails.length) {
-    const primaryEmail = registeredEmails[0]
+  if (emails.length) {
+    const primaryEmail = emails[0]
     fields.emailAddress = primaryEmail
     fields.email = primaryEmail
   }

--- a/linkedin-server.js
+++ b/linkedin-server.js
@@ -149,7 +149,7 @@ OAuth.registerService('linkedin', 2, null, query => {
 
   if (emails.length) {
     const primaryEmail = emails[0]
-    fields.emailAddress = primaryEmail
+    fields.emailAddress = primaryEmail // for backward compatibility with previous versions of this package
     fields.email = primaryEmail
   }
 

--- a/linkedin-server.js
+++ b/linkedin-server.js
@@ -24,7 +24,7 @@ const getRegisteredEmails = function(accessToken) {
   for (const element of response.elements) {
     emails.push(element['handle~'].emailAddress)
   }
-  return emails;
+  return emails
 }
 
 // checks whether a string parses as JSON
@@ -149,8 +149,8 @@ OAuth.registerService('linkedin', 2, null, query => {
 
   if (registeredEmails.length) {
     const primaryEmail = registeredEmails[0]
-    fields.emailAddress = primaryEmail;
-    fields.email = primaryEmail;
+    fields.emailAddress = primaryEmail
+    fields.email = primaryEmail
   }
 
   _.extend(serviceData, fields)

--- a/linkedin-server.js
+++ b/linkedin-server.js
@@ -15,7 +15,7 @@ const getImage = profilePicture => {
 }
 
 // Request for email, returns array
-const getEmail = function(accessToken) {
+const getRegisteredEmails = function(accessToken) {
   const url = encodeURI(
     `https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))&oauth2_access_token=${accessToken}`,
   )
@@ -24,7 +24,7 @@ const getEmail = function(accessToken) {
   for (const element of response.elements) {
     emails.push(element['handle~'].emailAddress)
   }
-  return emails
+  return emails;
 }
 
 // checks whether a string parses as JSON
@@ -137,12 +137,20 @@ OAuth.registerService('linkedin', 2, null, query => {
     expiresAt: +new Date() + 1000 * response.expiresIn,
   }
 
+  const registeredEmails = getRegisteredEmails(accessToken)
+
   const fields = {
     linkedinId: id,
     firstName,
     lastName,
     profilePicture: getImage(profilePicture),
-    email: getEmail(accessToken),
+    registeredEmails,
+  }
+
+  if (registeredEmails.length) {
+    const primaryEmail = registeredEmails[0]
+    fields.emailAddress = primaryEmail;
+    fields.email = primaryEmail;
   }
 
   _.extend(serviceData, fields)


### PR DESCRIPTION
The email value became a single-element array after the recent changes. Should be a String.